### PR TITLE
Makefile: Update Alpine to 3.13.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LNCR_EXE=Alpine.exe
 
 DLR=curl
 DLR_FLAGS=-L
-BASE_URL=http://dl-cdn.alpinelinux.org/alpine/v3.13/releases/x86_64/alpine-minirootfs-3.13.2-x86_64.tar.gz
+BASE_URL=http://dl-cdn.alpinelinux.org/alpine/v3.13/releases/x86_64/alpine-minirootfs-3.13.4-x86_64.tar.gz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/21020500/icons.zip
 LNCR_ZIP_EXE=Alpine.exe
 


### PR DESCRIPTION
Includes security updates for openssl and busybox.